### PR TITLE
Add support for Latitude 5290 2-in-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Dell Latitude 5285 2-in-1 — Camera fix for Linux (kernel 6.17+)
+# Dell Latitude 5285 / 5290 2-in-1 — Camera fix for Linux (kernel 6.17+)
 
-This documents how to get both cameras working on the **Dell Latitude 5285 2-in-1**
-under Ubuntu 25.10 with kernel 6.17, including Chrome (Google Meet) and Zoom.
+This documents how to get both cameras working on the **Dell Latitude 5285 / 5290 2-in-1**
+under Ubuntu, including Chrome (Google Meet) and Zoom.
+
+Repository and script names still use `5285` for historical reasons, but this
+repo supports both Latitude 5285 and Latitude 5290 2-in-1.
 
 **Hardware:**
 - Front: OV5670 (ACPI: INT3479, I2C4 / i2c_designware.4)
@@ -51,7 +54,7 @@ The OV5670 lives on I2C4, described by ACPI node INT3446. On this machine
 INT3446 conflicts with a legacy ACPI resource and the driver refuses to bind
 without `IGNORE_RESOURCE_CONFLICTS`.
 
-**Fix:** DMI quirk matching Dell Latitude 5285 + INT3446 → set
+**Fix:** DMI quirk matching Dell Latitude 5285/5290 + INT3446 → set
 `LPSS_SHARED_CLK | IGNORE_RESOURCE_CONFLICTS`.
 
 ### 2. `intel_skl_int3472_tps68470` — clock consumer registration
@@ -73,13 +76,13 @@ uses the board-supplied list instead of calling
 > `modprobe -r / modprobe` cycle gives 0 consumers → probe fails → no
 > clocks/regulators. **Always test by rebooting, not reloading.**
 
-### 3. `intel_skl_int3472_tps68470` — board data for Dell 5285
+### 3. `intel_skl_int3472_tps68470` — board data for Dell 5285/5290
 
 The driver needs a board-data entry for this machine telling it which TPS68470
 GPIOs are reset/powerdown for each sensor, and which regulators map to which
 supply names.
 
-**Fix:** Added `tps68470_board_data` entry for Dell 5285:
+**Fix:** Added `tps68470_board_data` entries for Dell 5285 and Latitude 5290 2-in-1:
 - INT3479 (OV5670): GPIO3 = reset (ACTIVE_LOW), GPIO4 = powerdown (ACTIVE_LOW)
 - INT3477 (OV8858): GPIO9 = s_resetn (ACTIVE_LOW), GPIO7 = s_enable (ACTIVE_LOW)
 - Regulators:
@@ -294,7 +297,7 @@ is open at the same time.
 
 ## Tested on
 
-- Machine: Dell Latitude 5285 2-in-1
+- Machines: Dell Latitude 5285 2-in-1, Dell Latitude 5290 2-in-1
 - OS: Ubuntu 25.10
 - Kernel: 6.17.0-22-generic (also tested on 6.17.0-19 and 6.17.0-20)
 - libcamera: system package (Ubuntu 25.10)

--- a/patches/lpss/intel-lpss-acpi.c
+++ b/patches/lpss/intel-lpss-acpi.c
@@ -191,6 +191,12 @@ static const struct dmi_system_id dell5285_lpss_dmi[] = {
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Latitude 5285"),
 		},
 	},
+	{
+		.matches = {
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Latitude 5290 2-in-1"),
+		},
+	},
 	{ }
 };
 
@@ -205,14 +211,14 @@ static int intel_lpss_acpi_probe(struct platform_device *pdev)
 		return -ENODEV;
 
 	/*
-	 * Apply IGNORE_RESOURCE_CONFLICTS for I2C4 on Dell Latitude 5285.
+	 * Apply IGNORE_RESOURCE_CONFLICTS for I2C4 on Dell Latitude 5285/5290.
 	 * The ACPI GEXP device conflicts with I2C4 (INT3446) MMIO resources
 	 * due to a BIOS bug where both use the same SB04 variable.
 	 */
 	if (acpi_dev_hid_uid_match(ACPI_COMPANION(&pdev->dev),
 				   "INT3446", NULL) &&
 	    dmi_check_system(dell5285_lpss_dmi)) {
-		dev_info(&pdev->dev, "Dell 5285: applying IGNORE_RESOURCE_CONFLICTS for I2C4\n");
+		dev_info(&pdev->dev, "Dell 5285/5290: applying IGNORE_RESOURCE_CONFLICTS for I2C4\n");
 		data = &spt_i2c_info_ignore_conflicts;
 	}
 

--- a/patches/tps68470/tps68470_board_data.c
+++ b/patches/tps68470/tps68470_board_data.c
@@ -318,8 +318,9 @@ static struct regulator_consumer_supply dell_5285_int3477_core_consumer_supplies
  * exactly (both 1800600 uV).  Mapping VSIO to dovdd/INT3477 means the
  * passthrough is enabled when the ov8858 driver enables its dovdd supply.
  */
-static struct regulator_consumer_supply dell_5285_int3477_vsio_consumer_supplies[] = {
+static struct regulator_consumer_supply dell_5285_vsio_consumer_supplies[] = {
 	REGULATOR_SUPPLY("dovdd", "i2c-INT3477:00"),
+	REGULATOR_SUPPLY("avdd", "i2c-INT3479:00"),
 };
 
 static struct regulator_consumer_supply dell_5285_int3479_aux1_consumer_supplies[] = {
@@ -370,8 +371,8 @@ static const struct regulator_init_data dell_5285_tps68470_vsio_reg_init_data = 
 		.apply_uV = 1,
 		.valid_ops_mask = REGULATOR_CHANGE_STATUS,
 	},
-	.num_consumer_supplies = ARRAY_SIZE(dell_5285_int3477_vsio_consumer_supplies),
-	.consumer_supplies = dell_5285_int3477_vsio_consumer_supplies,
+	.num_consumer_supplies = ARRAY_SIZE(dell_5285_vsio_consumer_supplies),
+	.consumer_supplies = dell_5285_vsio_consumer_supplies,
 };
 
 static const struct regulator_init_data dell_5285_tps68470_aux1_reg_init_data = {
@@ -477,6 +478,13 @@ static const struct dmi_system_id int3472_tps68470_board_data_table[] = {
 		.matches = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR,   "Dell Inc."),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Latitude 5285"),
+		},
+		.driver_data = (void *)&dell_5285_tps68470_board_data,
+	},
+	{
+		.matches = {
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR,   "Dell Inc."),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Latitude 5290 2-in-1"),
 		},
 		.driver_data = (void *)&dell_5285_tps68470_board_data,
 	},


### PR DESCRIPTION
## Summary
- Extend the kernel patch set to support the Dell Latitude 5290 2-in-1 in addition to the Latitude 5285.

## What changed
- Added a DMI match for `Latitude 5290 2-in-1` in `patches/lpss/intel-lpss-acpi.c` so the same INT3446 resource-conflict quirk is applied on 5290 hardware.
- Added a DMI match for `Latitude 5290 2-in-1` in `patches/tps68470/tps68470_board_data.c` so the existing TPS68470 board data is reused on 5290.
- Updated VSIO consumer mapping to cover both camera supply expectations (`dovdd` for INT3477 and `avdd` for INT3479), matching the required power behavior for dual-camera bring-up. This resolved a dmesg error for the missing `avdd` for INT3479.

## Why
- The Latitude 5290 2-in-1 shares the same camera topology and PMIC wiring model as the 5285 for the relevant paths, but it needs explicit DMI matching for quirk/board-data activation.

## Testing
- This patch has been tested on Ubuntu 26.04 with Linux 7.0

## Disclosure
- This PR was created using OpenCode and GPT 5.3 Codex